### PR TITLE
anyenv::setup check if it's been run

### DIFF
--- a/manifests/env.pp
+++ b/manifests/env.pp
@@ -12,7 +12,7 @@ define anyenv::env (
       require => Anchor["anyenv::env::${user}::${env}::begin"];
   }
 
-  if ! defined( Anchor["anyenv::setup::${user}::end"] ) {
+  if ! defined( Anchor["anyenv::setup::${user}::end"] ) and ! defined( Anyenv::Setup["anyenv_${user}"] ) {
     anyenv::setup { "anyenv_${user}":
       user    => $user,
       home    => $home,


### PR DESCRIPTION
When I install 2 *envs, it complaints the Anyenv::Setup["anyenv_deploy"] is already existing. 
